### PR TITLE
implement command line options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All Notable changes to `npm-install-peers` will be documented in this file.
 
+## 1.0.2
+- Added `peerInstallOptions` which can be used to provide different
+ [config flags](https://docs.npmjs.com/misc/config), for example, `no-bin-links`
+
 ## 1.0.1
 - Made compatible with older node versions
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "npm-install-peers",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "CLI command to install npm peerDependencies",
   "preferGlobal": true,
   "bin": {

--- a/src/index.js
+++ b/src/index.js
@@ -28,7 +28,9 @@ fs.readFile('package.json', 'utf-8', function(error, contents) {
         return `${key}@${peerDependencies[key]}`
     })
 
-    npm.load(function() {
+    let peerInstallOptions=packageContents.peerInstallOptions
+
+    npm.load(peerInstallOptions, function() {
         npm.commands.install(packages)
     })
 })

--- a/src/package.js
+++ b/src/package.js
@@ -18,6 +18,10 @@ class Package {
     get peerDependencies() {
         return this.contents.peerDependencies || []
     }
+
+    get peerInstallOptions() {
+        return this.contents.peerInstallOptions || {}
+    }
 }
 
 module.exports = Package


### PR DESCRIPTION
This is implementation of cli options. Unfortunately, I could not add this like I planned (add console options) because when you call npm programmatically, you should provide it with an object with properties, not with command line options. That means that for implementing command line options I would have to parse arguments and then make an object out of those... Also, there would be many troubles - for example, programmatical option `no-bin-links` does not exist, so I'd have to convert it somehow to `bin-links: false`. Too complex.

So I added check for custom section `peerInstallOptions` in package.json. That looks pretty simple:
```json
  "peerInstallOptions": {
    "bin-links": false
  }
```

Adding custom sections to `package.json` is [allowed](http://stackoverflow.com/questions/10065564/add-custom-metadata-or-config-to-package-json-is-it-valid) so I think that's the best way.