### PR TITLE
remove npm from deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "eslint": "^3.8.1"
   },
   "dependencies": {
-    "chalk": "^1.1.3",
-    "npm": "^3.3.9"
+    "chalk": "^1.1.3"
   }
 }


### PR DESCRIPTION
Sometimes npm install thinks... That there is no npm available. So when you try to install this module, npm... Installs npm locally. And it causes all sorts of troubles. I think that it's better to remove npm from dependencies.


References:
http://stackoverflow.com/questions/15054388/global-node-modules-not-installing-correctly-command-not-found
http://stackoverflow.com/questions/12594541/npm-global-install-cannot-find-module