### PR TITLE
Fix #17

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "eslint": "^3.8.1"
   },
   "dependencies": {
-    "chalk": "^1.1.3"
+    "chalk": "^1.1.3",
+    "npm": "^5.6.0"
   }
 }


### PR DESCRIPTION
`npm` is a dependency of `npm-install-peers`, so let's state that explicitly.