### PR TITLE
Fix: TypeError('must call as: npm.load(callback)') with npm version

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,6 @@
   },
   "dependencies": {
     "chalk": "^1.1.3",
-    "npm": "^7.0.0-beta.4"
+    "npm": "< 7.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "npm-install-peers",
-  "version": "1.2.1",
+  "version": "1.2.2-1",
   "description": "CLI command to install npm peerDependencies",
   "preferGlobal": true,
   "bin": {
@@ -34,6 +34,6 @@
   },
   "dependencies": {
     "chalk": "^1.1.3",
-    "npm": "*"
+    "npm": "^7.0.0-beta.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "npm-install-peers",
-  "version": "1.2.2-1",
+  "version": "1.2.1",
   "description": "CLI command to install npm peerDependencies",
   "preferGlobal": true,
   "bin": {


### PR DESCRIPTION
### Issue
With our repos, we have started noticing following error when we run `npm-install-peers` 
```
/Users/kheyalimitra/code/pfm/node_modules/npm/lib/npm.js:130
      throw new TypeError('must call as: npm.load(callback)')
      ^
TypeError: must call as: npm.load(callback)
    at Object.load (/Users/kheyalimitra/code/pfm/node_modules/npm/lib/npm.js:130:13)
    at /Users/kheyalimitra/code/pfm/node_modules/npm-install-peers/dist/index.js:40:9
    at /Users/kheyalimitra/code/pfm/node_modules/npm/node_modules/graceful-fs/graceful-fs.js:123:16
    at FSReqCallback.readFileAfterClose [as oncomplete] (internal/fs/read_file_context.js:63:3)
```
After carefully noticing, we see that we use npm version `6.14.X` and above.  Now, under dependency, this package uses, `npm:  *` and  it is resulting in pulling the latest version of `npm` which is v7. As in this latest version, the interface of the load function is not changed, it is throwing the above error. 

#### You can find more details here: 
- This is how `npm.load` is getting called here https://github.com/spatie/npm-install-peers/blob/master/src/index.js#L34
- But this is is how it is implemented in `npm` https://github.com/npm/cli/blob/latest/lib/npm.js#L128
- You can also see this has changed recently change from npm side by doing the blame report on the npm repo  https://github.com/npm/cli/blame/latest/lib/npm.js#L128

### Solution
Hence,  we are pinning the `npm` version to v6 as a quick fix. Although a proper fix would be to update the code to use the new syntax of the load function. 

We need this  quick fix only because we need to fix this ASAP as this is blocking our daily works. 